### PR TITLE
Fixes ENOSPC system limit instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ SpotSchema.virtual('thumbnail_url').get(function() {
 
 ### **ENOSPC: System limit for number of file watchers reached**
 
-- Em dispositivos Linux, o sistema pode ter uma certa limitação para o uso do live reload, o que ocasiona esse erro quando o diretório de algum projeto com a função ativada possui muitos arquivos. Execute o comando `echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc sysctl.conf && sudo sysctl -p` em seu terminal e o problema será resolvido.
+- Em dispositivos Linux, o sistema pode ter uma certa limitação para o uso do live reload, o que ocasiona esse erro quando o diretório de algum projeto com a função ativada possui muitos arquivos. Execute o comando `echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p` em seu terminal e o problema será resolvido.
 
 ### **KeyboardAvoidingView não funciona no Android**
 


### PR DESCRIPTION
Tive esse problema com a limitação de live reload na NLW 2. Porém, só consegui resolver quando alterei o caminho do arquivo `sysctl.conf`. Espero que ajude outras pessoas que estão com o mesmo problema. 