### PR TITLE
Utilizando Expo com WSL2 sem tunelamento (Tunnel)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,22 @@ Esse repositório contém uma série de erros (e suas soluções) que você pode
 
 ## Issues
 
-- [Expo command not found](#expo-command-not-found)
-- [Invalid Regular Expression](#invalid-regular-expression)
-- [Input is required, but Expo CLI is in non-interactive mode.](#input-is-required-but-expo-cli-is-in-non-interactive-mode)
-- [Network response timed out](#network-response-timed-out)
-- [The internet connection appears to be offline.](#the-internet-connection-appears-to-be-offline)
-- [Imagens não aparecendo no dispositivo físico](#imagens-n%c3%a3o-aparecendo-no-dispositivo-f%c3%adsico)
-- [Logo ou Texto aparecendo atrás das barra de status no Android](#logo-ou-texto-aparecendo-atr%c3%a1s-das-barra-de-status-no-android)
-- [ENOSPC: System limit for number of file watchers reached](#enospc-system-limit-for-number-of-file-watchers-reached)
-- [KeyboardAvoidingView não funciona no Android](#keyboardavoidingview-n%c3%a3o-funciona-no-android)
-- [UnauthorizedAccess on run Expo command on Microsoft PowerShell](#unauthorizedaccess-on-run-expo-command-on-microsoft-powershell)
-- [O arquivo não pode ser carregado](#o-arquivo-n%c3%a3o-pode-ser-carregado)
+- [Expo common issues](#expo-common-issues)
+  - [Issues](#issues)
+    - [**Expo command not found**](#expo-command-not-found)
+    - [**Invalid Regular Expression**](#invalid-regular-expression)
+    - [**Input is required, but Expo CLI is in non-interactive mode.**](#input-is-required-but-expo-cli-is-in-non-interactive-mode)
+    - [**Network response timed out**](#network-response-timed-out)
+    - [**The internet connection appears to be offline.**](#the-internet-connection-appears-to-be-offline)
+    - [**Imagens não aparecendo no dispositivo físico**](#imagens-não-aparecendo-no-dispositivo-físico)
+    - [**Logo ou Texto aparecendo atrás das barra de status no Android**](#logo-ou-texto-aparecendo-atrás-das-barra-de-status-no-android)
+    - [**ENOSPC: System limit for number of file watchers reached**](#enospc-system-limit-for-number-of-file-watchers-reached)
+    - [**KeyboardAvoidingView não funciona no Android**](#keyboardavoidingview-não-funciona-no-android)
+    - [**UnauthorizedAccess on run Expo command on Microsoft PowerShell**](#unauthorizedaccess-on-run-expo-command-on-microsoft-powershell)
+    - [**O arquivo não pode ser carregado**](#o-arquivo-não-pode-ser-carregado)
+    - [**Utilizando Expo com WSL2 sem tunelamento (Tunnel)**](#utilizando-expo-com-wsl2-sem-tunelamento-tunnel)
+      - [Manual](#manual)
+      - [Automático](#automático)
 
 ### **Expo command not found**
 
@@ -111,3 +116,35 @@ import { KeyboardAvoidingView, Platform } from 'react-native';
 - Ao executar o script `expo -h`, o Porwershell pode restringir sua execução. Para resolver o problema, basta remover a restrição com o comando `set-executionpolicy bypass` e executar o script do expo novamente. O comando `get-executionpolicy` pode ser utilizado para saber qual o nível de restrição está sendo utilizado.
 
 - Para mais informações sobre as restrições, acesse a [documentação da microsoft](https://support.microsoft.com/pt-br/help/2411920/you-can-t-run-scripts-in-azure-active-directory-module-for-windows-pow)
+
+### **Utilizando Expo com WSL2 sem tunelamento (Tunnel)**
+
+- A utilização do Expo no ambiente de desenvolvimento ***Windows + WSL2*** pode ser problemática devido ao modo como o **WSL2** se comunica com o **Windows**. Ao iniciar o projeto e abrir o Expo DevTools é possível ver que é atriubído o endereço IP do WSL2 para acesso no modo **LAN**, não sendo possível a conexão entre o dispositivo móvel e o computador. Uma alternativa seria a conexão através do modo **Tunnel** (tunelamento), porém essa opção pode não ser a mais agradável devido ao fato de nessecitar de conexão com a internet tornando o download dos pacotes (Downloading JavaScript bundle) mais lento, principalmente em projetos um pouco maiores. Para contornar isso é necessário realizar o "direcionamento" para o endereço IP correto que no caso, basicamente, seria o endereço IP utilizado no Windows.  
+
+- A configuração pode ser feita de duas maneiras, de forma **manual** ou **automática**!
+
+#### Manual
+
+Os passos para configuração são:  
+
+**1.** Abrir as portas necessárias **`(9000, 9001, 9002, 9003, etc)`** no firewall do Windows.
+**2.** Identificar o endereço IP do *Windows* e do *WSL2*.
+**3.** Redirecionar as portas entre *Windows* e *WSL2*.
+**4.** Configurar a variável de ambiente **`REACT_NATIVE_PACKAGER_HOSTNAME`** no *WSL2* para receber o endereço IP do *Windows*.
+
+- **Porém há um problema onde parte desse procedimento deve ser feito a cada reinicialização do sistema. Com o intuito de automatizar todo esse processo e evitar esses processos manuais foi criado um script para lidar com toda a configuração.**
+
+#### Automático
+
+Para utilizar o script [wsl2_host](https://github.com/jonhoffmam/wsl2_host):
+
+**1.** Faça uma cópia do repositório em sua máquina local:
+
+  ```sh
+  > git clone https://github.com/jonhoffmam/wsl2_host.git
+  ```
+
+**2.** Execute o arquivo **start.bat** na primeira execução do script.
+
+**Obs¹.:** A execução manual só é necessária na primeira execução, depois disso a cada logon o sistema irá executar automaticamente o script para configuração.
+**Obs².:** Posteriormente é possível executar o script com o comando **`wsl2host`** através do ***Executar*** `(Windows + "R")` caso necessário.

--- a/README.md
+++ b/README.md
@@ -4,20 +4,18 @@ Esse repositório contém uma série de erros (e suas soluções) que você pode
 
 ## Issues
 
-- [Expo common issues](#expo-common-issues)
-  - [Issues](#issues)
-    - [**Expo command not found**](#expo-command-not-found)
-    - [**Invalid Regular Expression**](#invalid-regular-expression)
-    - [**Input is required, but Expo CLI is in non-interactive mode.**](#input-is-required-but-expo-cli-is-in-non-interactive-mode)
-    - [**Network response timed out**](#network-response-timed-out)
-    - [**The internet connection appears to be offline.**](#the-internet-connection-appears-to-be-offline)
-    - [**Imagens não aparecendo no dispositivo físico**](#imagens-não-aparecendo-no-dispositivo-físico)
-    - [**Logo ou Texto aparecendo atrás das barra de status no Android**](#logo-ou-texto-aparecendo-atrás-das-barra-de-status-no-android)
-    - [**ENOSPC: System limit for number of file watchers reached**](#enospc-system-limit-for-number-of-file-watchers-reached)
-    - [**KeyboardAvoidingView não funciona no Android**](#keyboardavoidingview-não-funciona-no-android)
-    - [**UnauthorizedAccess on run Expo command on Microsoft PowerShell**](#unauthorizedaccess-on-run-expo-command-on-microsoft-powershell)
-    - [**O arquivo não pode ser carregado**](#o-arquivo-não-pode-ser-carregado)
-    - [**Utilizando Expo com WSL2 sem tunelamento (Tunnel)**](#utilizando-expo-com-wsl2-sem-tunelamento-tunnel)
+- [Expo command not found](#expo-command-not-found)
+- [Invalid Regular Expression](#invalid-regular-expression)
+- [Input is required, but Expo CLI is in non-interactive mode.](#input-is-required-but-expo-cli-is-in-non-interactive-mode)
+- [Network response timed out](#network-response-timed-out)
+- [The internet connection appears to be offline.](#the-internet-connection-appears-to-be-offline)
+- [Imagens não aparecendo no dispositivo físico](#imagens-n%c3%a3o-aparecendo-no-dispositivo-f%c3%adsico)
+- [Logo ou Texto aparecendo atrás das barra de status no Android](#logo-ou-texto-aparecendo-atr%c3%a1s-das-barra-de-status-no-android)
+- [ENOSPC: System limit for number of file watchers reached](#enospc-system-limit-for-number-of-file-watchers-reached)
+- [KeyboardAvoidingView não funciona no Android](#keyboardavoidingview-n%c3%a3o-funciona-no-android)
+- [UnauthorizedAccess on run Expo command on Microsoft PowerShell](#unauthorizedaccess-on-run-expo-command-on-microsoft-powershell)
+- [O arquivo não pode ser carregado](#o-arquivo-n%c3%a3o-pode-ser-carregado)
+- [Utilizando Expo com WSL2 sem tunelamento (Tunnel)](#utilizando-expo-com-wsl2-sem-tunelamento-tunnel)
 
 ### **Expo command not found**
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ Esse repositório contém uma série de erros (e suas soluções) que você pode
     - [**UnauthorizedAccess on run Expo command on Microsoft PowerShell**](#unauthorizedaccess-on-run-expo-command-on-microsoft-powershell)
     - [**O arquivo não pode ser carregado**](#o-arquivo-não-pode-ser-carregado)
     - [**Utilizando Expo com WSL2 sem tunelamento (Tunnel)**](#utilizando-expo-com-wsl2-sem-tunelamento-tunnel)
-      - [Manual](#manual)
-      - [Automático](#automático)
 
 ### **Expo command not found**
 
@@ -123,18 +121,18 @@ import { KeyboardAvoidingView, Platform } from 'react-native';
 
 - A configuração pode ser feita de duas maneiras, de forma **manual** ou **automática**!
 
-#### Manual
+**Modo Manual:**  
 
 Os passos para configuração são:  
 
-**1.** Abrir as portas necessárias **`(9000, 9001, 9002, 9003, etc)`** no firewall do Windows.
-**2.** Identificar o endereço IP do *Windows* e do *WSL2*.
-**3.** Redirecionar as portas entre *Windows* e *WSL2*.
-**4.** Configurar a variável de ambiente **`REACT_NATIVE_PACKAGER_HOSTNAME`** no *WSL2* para receber o endereço IP do *Windows*.
+**1.** Abrir as portas necessárias **`(9000, 9001, 9002, 9003, etc)`** no firewall do Windows.  
+**2.** Identificar o endereço IP do *Windows* e do *WSL2*.  
+**3.** Redirecionar as portas entre *Windows* e *WSL2*.  
+**4.** Configurar a variável de ambiente **`REACT_NATIVE_PACKAGER_HOSTNAME`** no *WSL2* para receber o endereço IP do *Windows*.  
 
-- **Porém há um problema onde parte desse procedimento deve ser feito a cada reinicialização do sistema. Com o intuito de automatizar todo esse processo e evitar esses processos manuais foi criado um script para lidar com toda a configuração.**
+- **Porém há um problema onde parte desse procedimento deve ser feito a cada reinicialização do sistema. Com o intuito de automatizar todo esse processo e evitar esses processos manuais foi criado um script para lidar com toda a configuração.**  
 
-#### Automático
+**Modo Automático:**  
 
 Para utilizar o script [wsl2_host](https://github.com/jonhoffmam/wsl2_host):
 

--- a/README.md
+++ b/README.md
@@ -142,5 +142,5 @@ Para utilizar o script [wsl2_host](https://github.com/jonhoffmam/wsl2_host):
 
 **2.** Execute o arquivo **start.bat** na primeira execução do script.
 
-**Obs¹.:** A execução manual só é necessária na primeira execução, depois disso a cada logon o sistema irá executar automaticamente o script para configuração.
+**Obs¹.:** A execução manual só é necessária na primeira execução, depois disso a cada logon o sistema irá executar automaticamente o script para configuração.  
 **Obs².:** Posteriormente é possível executar o script com o comando **`wsl2host`** através do ***Executar*** `(Windows + "R")` caso necessário.


### PR DESCRIPTION
Ao migrar do WSL para WSL2 me deparei com um problema que era conseguir conectar o dispositivo móvel com o computador utilizando o Expo DevTools. 
Devido as mudanças de como o WSL2 se comunica com o Windows o modo de conexão **LAN** era impossível de ser utilizado sem que realizasse algumas configurações, entre Windows e WSL2. 
Essas configurações permitem a conexão através do modo **LAN**  sem a necessidade de utilizar o modo **Tunnel**, porém devem ser feitas sempre que é realizado a reinicialização do sistema. 
Com isso criei um script capaz de automatizar esses processos com a finalidade de facilitar o uso do Expo nesse ambiente.